### PR TITLE
Incorporate cache-busting renaming into build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp": "^3.8.10",
     "gulp-autoprefixer": "^2.1.0",
     "gulp-cache": "^0.2.4",
+    "gulp-cachebust": "0.0.5",
     "gulp-changed": "^1.1.0",
     "gulp-chmod": "^1.2.0",
     "gulp-concat": "^2.4.3",
@@ -53,6 +54,7 @@
     "sw-precache": "^1.2.6",
     "through2": "0.6.3",
     "vinyl-map": "1.0.1",
+    "vinyl-paths": "^1.0.0",
     "yargs": "1.3.3"
   }
 }


### PR DESCRIPTION
R: all (See my comment at the end about the timing of merging this!)

This is a prerequisite for #640. Once it's in place, we should be okay to bump up the cache lifetimes of most of the static resource directories. I assume that @crhym3 will be the one to do that.

As mentioned in the comments on #640, the ordering in which the hash-based renaming happens is very important. E.g., if `fileA.css` contains `url('path/to/fileB.jpg')`, then `fileB.jpg` needs to first be renamed to `fileB.md5hash.jpg`, then `fileA.css`'s contents need to be updated to `url('path/to/fileB.md5hash.jpg')`, then `fileA.css` needs to be renamed to `fileA.md5hash.css`. And the process then repeats itself, for all the files that originally referenced to `fileA.css`, and so on.

Rather than try to maintain a mapping of specific file dependencies, or do some sort of code inspection to programmatically determine dependencies, I've structured the task in a few different "waves" in which a subset of files are renamed, then other files have their references updated, and so on. It seems to work for the current set of files, but please, double-check my logic!

One wrinkle that I raised in #640 that I have not been able to address is the problems with renaming the `elements/webgl-globe` shaders and textures, due to the dynamically constructed URLs used to load them. We would need to special-case the cache expiration for that shader and texture content, and make it something shorter than what we use for the static content that's properly versioned. The exact expiration that we should use depends on how confident @brendankenny is about whether anything might change. (Our planet's landmasses probably won't be rearranged between now and I/O?)

I do have concerns about this being fragile, and there are a few different scenarios I can imagine in which this logic would break down. One is if we introduce a new dependency that isn't captured in our current logic—e.g. we create a `scripts/fileC.js` that dynamically loads `scripts/fileD.js`, but both of those files end up being renamed in the same "wave". Another concern is that we might change our directory structure without updating the corresponding paths in this task. And there are probably other ways I'm not anticipating that this could break :smile: 

Long-lived HTTP caches are a noble goal, and I'm glad we have a path forward. I do think this is potentially dangerous enough that we'd want to hold off on merging until there's an anticipated "lull" in site traffic (i.e. not around registration time).
